### PR TITLE
Avatar Optimizerに対応。

### DIFF
--- a/Packages/world.anlabo.mdnailtool/Editor/AAOProcessor.cs
+++ b/Packages/world.anlabo.mdnailtool/Editor/AAOProcessor.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using VRC.SDKBase.Editor.BuildPipeline;
+using world.anlabo.mdnailtool.Runtime;
+
+namespace world.anlabo.mdnailtool.Editor {
+	public class AAOProcessor : IVRCSDKPreprocessAvatarCallback {
+		public int callbackOrder => -1025 - 1;
+
+		public bool OnPreprocessAvatar(GameObject avatarGameObject) {
+			var components = avatarGameObject.GetComponentsInChildren<MDNailObjectMarker>();
+            foreach (var component in components) {
+				Object.DestroyImmediate(component);
+			}
+			return true;
+		}
+	}
+}

--- a/Packages/world.anlabo.mdnailtool/Editor/AAOProcessor.cs
+++ b/Packages/world.anlabo.mdnailtool/Editor/AAOProcessor.cs
@@ -8,7 +8,7 @@ namespace world.anlabo.mdnailtool.Editor {
 
 		public bool OnPreprocessAvatar(GameObject avatarGameObject) {
 			var components = avatarGameObject.GetComponentsInChildren<MDNailObjectMarker>();
-            foreach (var component in components) {
+ 			foreach (var component in components) {
 				Object.DestroyImmediate(component);
 			}
 			return true;

--- a/Packages/world.anlabo.mdnailtool/Editor/AAOProcessor.cs.meta
+++ b/Packages/world.anlabo.mdnailtool/Editor/AAOProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e74b296d64e475c4ca2685c0aeaa086d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
![スクリーンショット 2024-07-25 125900](https://github.com/user-attachments/assets/ed30d318-3a19-4886-92bb-57103cbe26be)

現在アバターの最適化ツールとしてデファクトスタンダードになりつつある[Avatar Optimizer](https://github.com/anatawa12/AvatarOptimizer)使用時に、互換性エラーが発生する問題を修正します。
[Avatar Optimizer公式のトラブルシューティング](https://vpm.anatawa12.com/avatar-optimizer/ja/docs/developers/make-your-components-compatible-with-aao/)に従い、ランタイムではMDNailObjectMarkerを削除するコールバックを追加しました。 
MDNailObjectMarkerはネイルの削除や変更時のみ使用するため、ランタイムではこのコンポーネントは不要だと考えます。
ランタイム時だけ削除されるため、改変中やAvatar Optimizerを使用していない環境での影響はありません。